### PR TITLE
Change shebang /usr/bin/env to use python3

### DIFF
--- a/stegoveritas.py
+++ b/stegoveritas.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # TODO: Implement multi-threading pool: https://docs.python.org/3/library/concurrent.futures.html
 


### PR DESCRIPTION
Better to explicitly use pyhton3, since running the script in systems which have both python 2 and 3 installed, will fail when using v2 by default

![captura de tela 2019-01-01 as 18 26 52](https://user-images.githubusercontent.com/9597536/50576189-32159500-0df3-11e9-9666-46c49f576db9.png)