### PR TITLE
install_deps: Add support for Manjaro

### DIFF
--- a/stegoveritas/install_deps.py
+++ b/stegoveritas/install_deps.py
@@ -21,7 +21,7 @@ def main():
     elif dist_name == 'fedora':
         fedora()
         
-    elif dist_name in ['archlinux', 'arch', 'arch linux']:
+    elif dist_name in ['archlinux', 'arch', 'arch linux', 'manjaro', 'manjaro linux']:
         archlinux()
 
     else:


### PR DESCRIPTION
Since Manjaro is Arch based, the same path can be used.
Tested in Manjaro 18.1.5 by manually installing the listed archlinux packages.

```
$ stegoveritas file.png 
ERROR:StegoVeritas:Missing the following required packages: exiftool, foremost
ERROR:StegoVeritas:Either install them manually or run 'stegoveritas_install_deps'.
```
```
$ stegoveritas_install_deps
ERROR:stegoveritas.install_deps:Unhandled distribution to install deps: manjaro linux
ERROR:stegoveritas.install_deps:Please poke me or submit a PR.
```

