### PR TITLE
Added support for 4 more Debian based distros

### DIFF
--- a/stegoveritas/install_deps.py
+++ b/stegoveritas/install_deps.py
@@ -14,8 +14,9 @@ required_packages = ['exiftool', '7z', 'foremost']
 def main():
 
     dist_name = distro.name().lower()
-    
-    if dist_name in ['ubuntu', 'debian', 'kali', 'debian gnu/linux', 'kali gnu/linux']:
+
+    if dist_name in ['ubuntu', 'debian', 'kali', 'debian gnu/linux', 'kali gnu/linux', 'pop!_os', 'elementary os',
+                     'deepin', 'pureos']:
         debian()
 
     elif dist_name == 'fedora':


### PR DESCRIPTION
Pop OS,  Elementary OS, Deepin, and Pure OS weren't working correctly.
Adding them to the list of Debian based distros fixed it up.

All 4 work properly now

