### PR TITLE
Add linux mint to debian list for install_deps

### DIFF
--- a/stegoveritas/install_deps.py
+++ b/stegoveritas/install_deps.py
@@ -16,7 +16,7 @@ def main():
     dist_name = distro.name().lower()
 
     if dist_name in ['ubuntu', 'debian', 'kali', 'debian gnu/linux', 'kali gnu/linux', 'pop!_os', 'elementary os',
-                     'deepin', 'pureos']:
+                     'deepin', 'pureos', 'linux mint']:
         debian()
 
     elif dist_name == 'fedora':


### PR DESCRIPTION
I use this with Mint, so I figured I would pass it along - tested on Linux Mint 20.2.