### PR TITLE
Fix FileNotFoundError when CWD does not exist at argument parse time

### DIFF
--- a/stegoveritas/stegoveritas.py
+++ b/stegoveritas/stegoveritas.py
@@ -176,7 +176,7 @@ class StegoVeritas(object):
                                          epilog='Have a good example? Wish it did something more? Submit a ticket: https://github.com/bannsec/stegoVeritas')
 
         # Core Options
-        parser.add_argument('-out', metavar='dir', type=str, help='Directory to place output in. Defaults to ./results', default=os.path.join(os.getcwd(), 'results'))
+        parser.add_argument('-out', metavar='dir', type=str, help='Directory to place output in. Defaults to ./results', default=None)
         parser.add_argument('-debug', action='store_true', help='Enable debugging logging.')
         parser.add_argument('-password', type=str, default=None, help='When applicable, attempt to use this password to extract data.')
         parser.add_argument('-wordlist', type=str, default=None, help='When applicable, attempt to brute force with this wordlist.')
@@ -210,7 +210,7 @@ class StegoVeritas(object):
             logging.root.setLevel(logging.DEBUG)
 
         self.file_name = self.args.file_name
-        self.results_directory = self.args.out
+        self.results_directory = self.args.out if self.args.out is not None else os.path.join(os.getcwd(), 'results')
 
         # Should this be considered an 'auto' run?
         # TODO: This is SUPER hacky... Should probably find a better way to determine if this is an auto run or not.

--- a/stegoveritas/stegoveritas.py
+++ b/stegoveritas/stegoveritas.py
@@ -95,7 +95,12 @@ class StegoVeritas(object):
             tmp_scan_file = os.path.join(tmpdirname, 'scanme')
 
             # Couldn't find a good 'output directory' option for binwalk. Changing dirs because of this.
-            saved_dir = os.getcwd()
+            # Use an open fd rather than a path so the restore survives CWD deletion
+            # (e.g. a prior test left the process in a since-deleted temp directory).
+            try:
+                saved_fd = os.open('.', os.O_RDONLY | os.O_DIRECTORY)
+            except OSError:
+                saved_fd = None
             os.chdir(tmpdirname)
 
             with open(tmp_scan_file, 'wb') as f:
@@ -148,7 +153,11 @@ class StegoVeritas(object):
 
                     shutil.move(keeper, keeper_dst)
 
-            os.chdir(saved_dir)
+            if saved_fd is not None:
+                os.fchdir(saved_fd)
+                os.close(saved_fd)
+            else:
+                os.chdir(self.results_directory)
 
         # TODO: Check if strings of output contain a known word, save if so.
 


### PR DESCRIPTION
## Problems

Two separate `FileNotFoundError` crash sites were found while packaging stegoveritas for Pentoo Linux:
https://github.com/pentoo/pentoo-overlay/pull/2923

### 1. `add_argument` default evaluated eagerly (line 179)

```python
parser.add_argument('-out', ..., default=os.path.join(os.getcwd(), 'results'))
```

Python evaluates `default=` when `add_argument()` is called, not when `-out` is absent. If the process CWD has been deleted at that point, `os.getcwd()` raises `FileNotFoundError` before any test body runs.

**Fix:** use `default=None` and resolve lazily at the `results_directory` assignment site.

### 2. `os.getcwd()` / `os.chdir()` in binwalk scan path (line 98)

```python
saved_dir = os.getcwd()
os.chdir(tmpdirname)
# ... binwalk.scan() — uses multiprocessing internally ...
os.chdir(saved_dir)
```

Two issues here:

- If a *previous* test left the process in a since-deleted temp directory, `os.getcwd()` fails immediately.
- binwalk uses `multiprocessing` internally. On some platforms Python's `multiprocessing.spawn` serialises the parent CWD and tries to restore it in the child. If `tmpdirname` is removed between spawn and child startup, `spawn.py` raises `FileNotFoundError`.

**Fix:** save the current directory as an `O_RDONLY` fd with `os.open('.')` and restore with `os.fchdir()`. An open fd keeps the inode alive even if the path is later unlinked, and `fchdir` never has to resolve a path. Fall back to `self.results_directory` if the initial `open` fails (CWD already gone).

---

Note: a separate failure (`AttributeError: module 'capstone' has no attribute 'CS_ARCH_ARM64'`) is caused by a capstone 5.x API change in `binwalk/modules/disasm.py` and is outside the scope of this PR.